### PR TITLE
feat: added map reset and round system

### DIFF
--- a/src/main/java/net/bigyous/gptgodmc/GPT/GptActions.java
+++ b/src/main/java/net/bigyous/gptgodmc/GPT/GptActions.java
@@ -30,7 +30,7 @@ public class GptActions {
         TypeToken<Map<String, String>> mapType = new TypeToken<Map<String, String>>() {
         };
         Map<String, String> argsMap = gson.fromJson(args, mapType);
-        Player player = GPTGOD.SERVER.getPlayer(argsMap.get("playerName"));
+        Player player = GPTGOD.SERVER.getPlayerExact(argsMap.get("playerName"));
         player.sendRichMessage("<i>You hear something whisper to you...</i>");
         player.sendMessage(argsMap.get("message"));
     };

--- a/src/main/java/net/bigyous/gptgodmc/GPTGOD.java
+++ b/src/main/java/net/bigyous/gptgodmc/GPTGOD.java
@@ -1,10 +1,18 @@
 package net.bigyous.gptgodmc;
 
 import de.maxhenkel.voicechat.api.BukkitVoicechatService;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
 import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
 import javax.annotation.Nullable;
 import net.bigyous.gptgodmc.utils.DebugCommand;
@@ -35,11 +43,26 @@ public final class GPTGOD extends JavaPlugin {
         getConfig().options().copyDefaults(true);
         saveConfig();
         getCommand("try").setExecutor(new DebugCommand());
+        Path worlds = getDataFolder().toPath().resolve("worlds");
+        if(getConfig().getString("startingWorld").isBlank()|| !getConfig().getBoolean("Rounds")){
+            String message = getConfig().getBoolean("Rounds")?
+            "can't use Round system since startingWorld is not set. Go to %s to fix this.":
+            "Round System disabled be warned, this is not the intended way to use gptgodmc. Go to %s to fix this";
+            LOGGER.warn(String.format(message, this.getDataFolder().getPath() + "\\config.yml"));
+        }
+        else{
+            if(WorldManager.loadMap(getConfig().getString("startingWorld"))){
+                SERVER.getPluginManager().registerEvents(new RoundSystem(), this);
+            }
+            
+        }
+        
 
     }
 
     @Override
     public void onDisable() {
+        WorldManager.unload();
         if (voicechatPlugin != null) {
             getServer().getServicesManager().unregister(voicechatPlugin);
             LOGGER.info("Successfully unregistered monitor plugin");

--- a/src/main/java/net/bigyous/gptgodmc/LocalGameMap.java
+++ b/src/main/java/net/bigyous/gptgodmc/LocalGameMap.java
@@ -33,18 +33,22 @@ public class LocalGameMap {
             GPTGOD.LOGGER.error("Loading GameMap Failed", e);
             return false;
         }
-
+        while(Bukkit.isTickingWorlds()){
+            Thread.onSpinWait();
+        }
         this.bukkitWorld = Bukkit.createWorld( new WorldCreator(activeWorldFolder.getName()));
 
         if(bukkitWorld != null){
             this.bukkitWorld.setAutoSave(false);
-            GPTGOD.SERVER.getOnlinePlayers().forEach(player -> player.teleport(bukkitWorld.getSpawnLocation()));
         }
         return isLoaded();
     }
 
     
     public void unload() {
+        while(Bukkit.isTickingWorlds()){
+            Thread.onSpinWait();
+        }
         if (bukkitWorld != null) Bukkit.unloadWorld(bukkitWorld, false);
         if (activeWorldFolder != null){
             try {

--- a/src/main/java/net/bigyous/gptgodmc/LocalGameMap.java
+++ b/src/main/java/net/bigyous/gptgodmc/LocalGameMap.java
@@ -1,0 +1,80 @@
+package net.bigyous.gptgodmc;
+
+import org.apache.commons.io.FileUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class LocalGameMap {
+    private final File sourceWorldFolder;
+    private File activeWorldFolder;
+    private String worldName;
+    private World bukkitWorld;
+
+
+    public LocalGameMap(File worldFolder, String worldName, boolean loadOnInit ){
+        this.sourceWorldFolder = new File(worldFolder, worldName);
+        if(loadOnInit) load();
+        this.worldName = worldName;
+    }
+
+    
+    public boolean load() {
+        if(isLoaded()) return true;
+        this.activeWorldFolder = new File(Bukkit.getWorldContainer(),
+            sourceWorldFolder.getName() + "_active_" + System.currentTimeMillis());
+        try {
+            FileUtils.copyDirectory(sourceWorldFolder, activeWorldFolder);
+        } catch (IOException e) {
+            GPTGOD.LOGGER.error("Loading GameMap Failed", e);
+            return false;
+        }
+
+        this.bukkitWorld = Bukkit.createWorld( new WorldCreator(activeWorldFolder.getName()));
+
+        if(bukkitWorld != null){
+            this.bukkitWorld.setAutoSave(false);
+            GPTGOD.SERVER.getOnlinePlayers().forEach(player -> player.teleport(bukkitWorld.getSpawnLocation()));
+        }
+        return isLoaded();
+    }
+
+    
+    public void unload() {
+        if (bukkitWorld != null) Bukkit.unloadWorld(bukkitWorld, false);
+        if (activeWorldFolder != null){
+            try {
+                FileUtils.deleteDirectory(activeWorldFolder);
+            } catch (IOException e) {
+                GPTGOD.LOGGER.error("Unloading World failed", e);
+                return;
+            }
+        }
+        this.bukkitWorld = null;
+        this.activeWorldFolder = null;
+    }
+
+    
+    public boolean restoreFromSource() {
+        unload();
+        return load();
+    }
+
+    
+    public boolean isLoaded() {
+        return bukkitWorld != null;
+    }
+
+    
+    public World getWorld() {
+        return bukkitWorld;
+    }
+
+    public String getWorldName() {
+         return worldName;
+    }
+}

--- a/src/main/java/net/bigyous/gptgodmc/RoundSystem.java
+++ b/src/main/java/net/bigyous/gptgodmc/RoundSystem.java
@@ -1,0 +1,35 @@
+package net.bigyous.gptgodmc;
+
+import org.bukkit.GameMode;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+public class RoundSystem implements Listener {
+    FileConfiguration config = JavaPlugin.getPlugin(GPTGOD.class).getConfig();
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event){
+        if(!config.getBoolean("Rounds") || config.getString("startingWorld").isBlank()) return;
+        Player player = event.getPlayer();
+        Server server = player.getServer();
+        player.setGameMode(GameMode.SPECTATOR);
+
+       for(Player p : server.getOnlinePlayers()){
+            if(!p.getGameMode().equals(GameMode.SPECTATOR)){
+                return;
+            }
+       }
+
+       WorldManager.resetCurrentMap();
+
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event){
+        WorldManager.teleportPlayer(event.getPlayer());
+    }
+}

--- a/src/main/java/net/bigyous/gptgodmc/RoundSystem.java
+++ b/src/main/java/net/bigyous/gptgodmc/RoundSystem.java
@@ -24,12 +24,24 @@ public class RoundSystem implements Listener {
             }
        }
 
-       WorldManager.resetCurrentMap();
+       reset();
 
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event){
         WorldManager.teleportPlayer(event.getPlayer());
+    }
+
+    public static void reset(){
+        WorldManager.resetCurrentMap();
+        for(Player p : GPTGOD.SERVER.getOnlinePlayers()){
+            revivePlayer(p);
+        }
+    }
+
+    public static void revivePlayer(Player player){
+            WorldManager.teleportPlayer(player);
+            player.setGameMode(GameMode.SURVIVAL);
     }
 }

--- a/src/main/java/net/bigyous/gptgodmc/WorldManager.java
+++ b/src/main/java/net/bigyous/gptgodmc/WorldManager.java
@@ -77,7 +77,9 @@ public class WorldManager {
 
     public static void teleportPlayer(Player player){
         if(!hasWorldLoaded()) return;
+        player.setRespawnLocation(currentGameMap.getWorld().getSpawnLocation(), true);
         player.teleport(currentGameMap.getWorld().getSpawnLocation());
+        
     }
 
 }

--- a/src/main/java/net/bigyous/gptgodmc/WorldManager.java
+++ b/src/main/java/net/bigyous/gptgodmc/WorldManager.java
@@ -1,0 +1,83 @@
+package net.bigyous.gptgodmc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class WorldManager {
+    private static Path WORLD_FOLDER = JavaPlugin.getPlugin(GPTGOD.class).getDataFolder().toPath().resolve("worlds");
+    private static HashMap<String, LocalGameMap> worldMaps = null;
+    private static LocalGameMap currentGameMap = null;
+    private static boolean worldCurrentlyLoaded = false;
+    public static void init(){
+        if (worldMaps != null){
+            return;
+        }
+        worldMaps = new HashMap<String, LocalGameMap>();
+        try {
+            Files.walk(WORLD_FOLDER, 1).forEach(world -> {
+                GPTGOD.LOGGER.info(String.format("world %s found in %s", world.getFileName().toString(), WORLD_FOLDER.toString()));
+                worldMaps.put(world.getFileName().toString(), new LocalGameMap(WORLD_FOLDER.toFile(), world.getFileName().toString(), false));
+            });
+        } catch (IOException e) {
+            GPTGOD.LOGGER.error("Getting world Folder failed :(", e);
+        }
+    }
+
+    private static LocalGameMap getGameMap(String mapName){
+        if (worldMaps == null){
+            init();
+        }
+        if(worldMaps.containsKey(mapName)){
+            return worldMaps.get(mapName);
+        }
+        return null;
+    }
+
+    public static boolean loadMap(String mapName){
+        LocalGameMap map = getGameMap(mapName);
+        if(map != null){
+            map.load();
+            currentGameMap = map;
+            worldCurrentlyLoaded = true;
+            GPTGOD.LOGGER.info(String.format("Map %s has been loaded", mapName));
+            return true;
+        }
+        else{
+            GPTGOD.LOGGER.warn(String.format("mapName %s does not exist in %s", mapName, WORLD_FOLDER.toString()));
+            return false;
+        }
+    }
+    public static void resetCurrentMap(){
+        if(currentGameMap == null){
+            GPTGOD.LOGGER.warn("no Managed GameMap loaded, reset failed");
+            return;
+        }
+        currentGameMap.restoreFromSource();
+    }
+
+    public static boolean hasWorldLoaded(){
+        return worldCurrentlyLoaded;
+    }
+
+    public static void unload(){
+        if(currentGameMap == null){
+            return;
+        }
+        currentGameMap.unload();
+        GPTGOD.LOGGER.info(String.format("Map %s has been unloaded", currentGameMap.getWorldName()));
+        currentGameMap = null;
+        worldCurrentlyLoaded = false;
+        
+    }
+
+    public static void teleportPlayer(Player player){
+        if(!hasWorldLoaded()) return;
+        player.teleport(currentGameMap.getWorld().getSpawnLocation());
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,3 +8,15 @@ openAiKey: ""
 
 # language in ISO-639 format https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 language: en
+
+# if set to true:
+# - When players die they are put in spectator mode
+# - When everyone dies the map is reset
+# This is the intended way to play
+# only set to false for testing and debugging
+Rounds: true
+
+# the world the server will load on starting
+# worlds are stored in plugins/gptgodmc/worlds
+# if empty or invalid the Round System won't work
+startingWorld: ""


### PR DESCRIPTION
added the ability to have a selection of worlds and dynamically load them in to reset the map. I will add voting later. When a player die they are put into spectator mode, and when everyone dies the game resets.
I need to make it so that the dead are put in a separate voice chat group.