### PR TITLE
fix: json parse error

### DIFF
--- a/src/main/java/net/bigyous/gptgodmc/GPT/Json/GptResponse.java
+++ b/src/main/java/net/bigyous/gptgodmc/GPT/Json/GptResponse.java
@@ -8,7 +8,6 @@ public class GptResponse {
     private int created;
     private String model;
     private Choice[] choices;
-    private Map<String, Integer> usage;
 
     public Choice[] getChoices() {
         return choices;
@@ -25,9 +24,5 @@ public class GptResponse {
 
     public String getObject() {
         return object;
-    }
-
-    public Map<String, Integer> getUsage() {
-        return usage;
     }
 }


### PR DESCRIPTION
removed useless json object from the parser. OpenAI changed the format of the usage object