### PR TITLE
feat: add multi-provider LLM inference support

### DIFF
--- a/src/main/java/net/bigyous/gptgodmc/GPT/GptAPI.java
+++ b/src/main/java/net/bigyous/gptgodmc/GPT/GptAPI.java
@@ -32,7 +32,6 @@ import net.bigyous.gptgodmc.GPT.Json.ParameterExclusion;
 public class GptAPI {
     private GsonBuilder gson = new GsonBuilder();
     private GptRequest body;
-    private String CHATGPTURL = "https://api.openai.com/v1/chat/completions";
     private Map<String, Integer> messageMap = new HashMap<String, Integer>();
     private boolean isSending = false;
     private static ExecutorService pool = Executors.newCachedThreadPool();
@@ -131,29 +130,162 @@ public class GptAPI {
         return body.getModel().getName();
     }
 
+    private String providerName(FileConfiguration config){
+        return config.getString("inference-provider", "openai").toLowerCase();
+    }
+
+    private boolean providerIsOpenAICompatible(String provider){
+        return provider.equals("openai") || provider.equals("openrouter") || provider.equals("lmstudio") || provider.equals("generic") || provider.equals("nim");
+    }
+
+    private String resolveChatUrl(FileConfiguration config){
+        String provider = providerName(config);
+        return switch(provider){
+            case "openrouter" -> config.getString("openRouterUrl", "https://api.openrouter.ai/v1") + "/chat/completions";
+            case "ollama" -> config.getString("ollamaUrl", "http://localhost:11434") + "/api/generate";
+            case "lmstudio" -> config.getString("lmstudioUrl", "http://127.0.0.1:8080") + "/v1/chat/completions";
+            case "generic" -> config.getString("genericUrl", "https://api.your-provider.example") + "/v1/chat/completions";
+            case "nim" -> config.getString("nimUrl", "https://integrate.api.nvidia.com/v1") + "/v1/chat/completions";
+            default -> "https://api.openai.com/v1/chat/completions";
+        };
+    }
+
+    private String resolveAuthHeader(FileConfiguration config){
+        String provider = providerName(config);
+        return switch(provider){
+            case "openrouter" -> "Bearer " + config.getString("openRouterKey", "");
+            case "openai" -> "Bearer " + config.getString("openAiKey", "");
+            case "generic" -> "Bearer " + config.getString("genericKey", "");
+            case "nim" -> "Bearer " + config.getString("nimKey", "");
+            default -> null; // local providers typically don't use a bearer header
+        };
+    }
+
+    private String messagesToPrompt(){
+        // convert chat messages to a single textual prompt for providers that expect a prompt string
+        StringBuilder prompt = new StringBuilder();
+        try{
+            for (var m : this.body.getMessages()){
+                prompt.append(m.getRole()).append(": ").append(m.getContent()).append("\n");
+            }
+        } catch(Exception e){
+            // fallback to serializing the whole body
+            prompt.append(gson.create().toJson(this.body));
+        }
+        return prompt.toString();
+    }
+
+    private String extractTextFromProviderResponse(String raw){
+        try{
+            var json = gson.fromJson(raw, com.google.gson.JsonElement.class);
+            if(json.isJsonObject()){
+                var obj = json.getAsJsonObject();
+                // common fields used by various local servers
+                if(obj.has("text")) return obj.get("text").getAsString();
+                if(obj.has("response")) return obj.get("response").getAsString();
+                if(obj.has("result")) return obj.get("result").getAsString();
+                // try a nested 'choices[0].message.content' like OpenAI
+                if(obj.has("choices")){
+                    var choices = obj.getAsJsonArray("choices");
+                    if(choices.size() > 0){
+                        var first = choices.get(0).getAsJsonObject();
+                        if(first.has("message")){
+                            var msg = first.getAsJsonObject("message");
+                            if(msg.has("content")) return msg.get("content").getAsString();
+                        }
+                        if(first.has("text")) return first.get("text").getAsString();
+                    }
+                }
+            }
+        } catch(Exception ignored){ }
+        // if we couldn't parse, return raw trimmed
+        return raw == null ? "" : raw.trim();
+    }
+
     public void send() {
         CloseableHttpClient client = HttpClientBuilder.create().build();
         pool.execute(() -> {
             this.isSending = true;
             FileConfiguration config = JavaPlugin.getPlugin(GPTGOD.class).getConfig();
-            StringEntity data = new StringEntity(gson.create().toJson(body), ContentType.APPLICATION_JSON);
-            GPTGOD.LOGGER.info("POSTING " + gson.setPrettyPrinting().create().toJson(body));
-            HttpPost post = new HttpPost(CHATGPTURL);
-            post.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + config.getString("openAiKey"));
-            GPTGOD.LOGGER.info("Making POST request");
-            post.setEntity(data);
+            String provider = providerName(config);
+
             try {
-                HttpResponse response = client.execute(post);
-                String out = new String(response.getEntity().getContent().readAllBytes());
-                EntityUtils.consume(response.getEntity());
-                GPTGOD.LOGGER.info("recieved response from OpenAI: " + out);
-                if (response.getStatusLine().getStatusCode() != 200) {
-                    GPTGOD.LOGGER.warn("API call failed");
-                    this.isSending = false;
+                String url = resolveChatUrl(config);
+                StringEntity data;
+                HttpPost post = new HttpPost(url);
+
+                if(providerIsOpenAICompatible(provider)){
+                    var payload = new com.google.gson.JsonObject();
+                    payload.add("messages", gson.toJsonTree(body.getMessages()));
+                    payload.addProperty("model", body.getModel().getName());
+                    // include tools if present
+                    if(body.getTools() != null && body.getTools().length > 0){
+                        payload.add("tools", gson.toJsonTree(body.getTools()));
+                        if(body.getTool_choice() != null){
+                            payload.add("tool_choice", gson.toJsonTree(body.getTool_choice()));
+                        }
+                    }
+                    // NIM-specific extra_body
+                    if(provider.equals("nim")){
+                        String extra = config.getString("nimExtraBody", "{}");
+                        try{
+                            var extraJson = com.google.gson.JsonParser.parseString(extra).getAsJsonObject();
+                            for(var entry : extraJson.entrySet()){
+                                payload.add(entry.getKey(), entry.getValue());
+                            }
+                        } catch(Exception ignored){}
+                    }
+                    data = new StringEntity(payload.toString(), ContentType.APPLICATION_JSON);
+                    String auth = resolveAuthHeader(config);
+                    if(auth != null) post.setHeader(HttpHeaders.AUTHORIZATION, auth);
+                } else {
+                    // build a simple prompt-based request for local servers (ollama / lmstudio)
+                    var map = new java.util.HashMap<String, Object>();
+                    map.put("model", body.getModel().getName());
+                    map.put("prompt", messagesToPrompt());
+                    // don't include functions/tooling for non-OpenAI providers
+                    data = new StringEntity(gson.create().toJson(map), ContentType.APPLICATION_JSON);
                 }
-                GptActions.processResponse(out);
+
+                GPTGOD.LOGGER.info("POSTING (" + provider + ") " + gson.setPrettyPrinting().create().toJson(body));
+                post.setEntity(data);
+                GPTGOD.LOGGER.info("Making POST request to " + url);
+
+                HttpResponse response = client.execute(post);
+                String raw = new String(response.getEntity().getContent().readAllBytes());
+                EntityUtils.consume(response.getEntity());
+
+                if(providerIsOpenAICompatible(provider)){
+                    GPTGOD.LOGGER.info("received response from " + provider + ": " + raw);
+                    if (response.getStatusLine().getStatusCode() != 200) {
+                        GPTGOD.LOGGER.warn("API call failed");
+                        this.isSending = false;
+                    }
+                    GptActions.processResponse(raw);
+                } else {
+                    // convert local provider response into the OpenAI-like envelope expected by the rest of the plugin
+                    String text = extractTextFromProviderResponse(raw);
+                    var synthetic = new com.google.gson.JsonObject();
+                    synthetic.addProperty("id", provider + "-" + System.currentTimeMillis());
+                    synthetic.addProperty("object", "chat.completion");
+                    synthetic.addProperty("created", (int) (System.currentTimeMillis() / 1000));
+                    synthetic.addProperty("model", body.getModel().getName());
+                    var choices = new com.google.gson.JsonArray();
+                    var choice = new com.google.gson.JsonObject();
+                    choice.addProperty("index", 0);
+                    var message = new com.google.gson.JsonObject();
+                    message.addProperty("role", "assistant");
+                    message.addProperty("content", text);
+                    choice.add("message", message);
+                    choice.addProperty("finish_reason", "stop");
+                    choices.add(choice);
+                    synthetic.add("choices", choices);
+                    String out = gson.create().toJson(synthetic);
+                    GPTGOD.LOGGER.info("mapped " + provider + " response to OpenAI format: " + out);
+                    GptActions.processResponse(out);
+                }
+
                 client.close();
-                // after everything finishes executing, the request is finished
                 Bukkit.getScheduler().runTaskLater(JavaPlugin.getPlugin(GPTGOD.class), () -> {
                     this.isSending = false;
                 }, 10);
@@ -169,24 +301,82 @@ public class GptAPI {
         pool.execute(() -> {
             this.isSending = true;
             FileConfiguration config = JavaPlugin.getPlugin(GPTGOD.class).getConfig();
-            StringEntity data = new StringEntity(gson.create().toJson(body), ContentType.APPLICATION_JSON);
-            GPTGOD.LOGGER.info("POSTING " + gson.setPrettyPrinting().create().toJson(body));
-            HttpPost post = new HttpPost(CHATGPTURL);
-            post.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + config.getString("openAiKey"));
-            GPTGOD.LOGGER.info("Making POST request");
-            post.setEntity(data);
+            String provider = providerName(config);
+
             try {
-                HttpResponse response = client.execute(post);
-                String out = new String(response.getEntity().getContent().readAllBytes());
-                EntityUtils.consume(response.getEntity());
-                GPTGOD.LOGGER.info("recieved response from OpenAI: " + out);
-                if (response.getStatusLine().getStatusCode() != 200) {
-                    GPTGOD.LOGGER.warn("API call failed");
-                    this.isSending = false;
+                String url = resolveChatUrl(config);
+                StringEntity data;
+                HttpPost post = new HttpPost(url);
+
+                if(providerIsOpenAICompatible(provider)){
+                    var payload = new com.google.gson.JsonObject();
+                    payload.add("messages", gson.toJsonTree(body.getMessages()));
+                    payload.addProperty("model", body.getModel().getName());
+                    if(body.getTools() != null && body.getTools().length > 0){
+                        payload.add("tools", gson.toJsonTree(body.getTools()));
+                        if(body.getTool_choice() != null){
+                            payload.add("tool_choice", gson.toJsonTree(body.getTool_choice()));
+                        }
+                    }
+                    // NIM-specific extra_body
+                    if(provider.equals("nim")){
+                        String extra = config.getString("nimExtraBody", "{}");
+                        try{
+                            var extraJson = com.google.gson.JsonParser.parseString(extra).getAsJsonObject();
+                            for(var entry : extraJson.entrySet()){
+                                payload.add(entry.getKey(), entry.getValue());
+                            }
+                        } catch(Exception ignored){}
+                    }
+                    data = new StringEntity(payload.toString(), ContentType.APPLICATION_JSON);
+                    String auth = resolveAuthHeader(config);
+                    if(auth != null) post.setHeader(HttpHeaders.AUTHORIZATION, auth);
+                } else {
+                    // functions are not supported for non-OpenAI-compatible providers; fall back to prompt-only
+                    var map = new java.util.HashMap<String, Object>();
+                    map.put("model", body.getModel().getName());
+                    map.put("prompt", messagesToPrompt());
+                    data = new StringEntity(gson.create().toJson(map), ContentType.APPLICATION_JSON);
                 }
-                GptActions.processResponse(out, functions);
+
+                GPTGOD.LOGGER.info("POSTING (" + provider + ") " + gson.setPrettyPrinting().create().toJson(body));
+                post.setEntity(data);
+                GPTGOD.LOGGER.info("Making POST request to " + url);
+
+                HttpResponse response = client.execute(post);
+                String raw = new String(response.getEntity().getContent().readAllBytes());
+                EntityUtils.consume(response.getEntity());
+
+                if(providerIsOpenAICompatible(provider)){
+                    GPTGOD.LOGGER.info("received response from " + provider + ": " + raw);
+                    if (response.getStatusLine().getStatusCode() != 200) {
+                        GPTGOD.LOGGER.warn("API call failed");
+                        this.isSending = false;
+                    }
+                    GptActions.processResponse(raw, functions);
+                } else {
+                    String text = extractTextFromProviderResponse(raw);
+                    var synthetic = new com.google.gson.JsonObject();
+                    synthetic.addProperty("id", provider + "-" + System.currentTimeMillis());
+                    synthetic.addProperty("object", "chat.completion");
+                    synthetic.addProperty("created", (int) (System.currentTimeMillis() / 1000));
+                    synthetic.addProperty("model", body.getModel().getName());
+                    var choices = new com.google.gson.JsonArray();
+                    var choice = new com.google.gson.JsonObject();
+                    choice.addProperty("index", 0);
+                    var message = new com.google.gson.JsonObject();
+                    message.addProperty("role", "assistant");
+                    message.addProperty("content", text);
+                    choice.add("message", message);
+                    choice.addProperty("finish_reason", "stop");
+                    choices.add(choice);
+                    synthetic.add("choices", choices);
+                    String out = gson.create().toJson(synthetic);
+                    GPTGOD.LOGGER.info("mapped " + provider + " response to OpenAI format: " + out);
+                    GptActions.processResponse(out, functions);
+                }
+
                 client.close();
-                // after everything finishes, executing the request is finished
                 Bukkit.getScheduler().runTaskLater(JavaPlugin.getPlugin(GPTGOD.class), () -> {
                     this.isSending = false;
                 }, 20);

--- a/src/main/java/net/bigyous/gptgodmc/GPT/Json/GptRequest.java
+++ b/src/main/java/net/bigyous/gptgodmc/GPT/Json/GptRequest.java
@@ -56,6 +56,10 @@ public class GptRequest {
         return messages.size();
     }
 
+    public ArrayList<GptMessage> getMessages(){
+        return messages;
+    }
+
     public void replaceMessage(int index, String message){
         this.messages.set(index, new GptMessage(this.messages.get(index).getRole(), message));
     }

--- a/src/main/java/net/bigyous/gptgodmc/enums/InferenceProvider.java
+++ b/src/main/java/net/bigyous/gptgodmc/enums/InferenceProvider.java
@@ -1,0 +1,10 @@
+package net.bigyous.gptgodmc.enums;
+
+public enum InferenceProvider {
+    OPENAI,
+    OPENROUTER,
+    OLLAMA,
+    LMSTUDIO,
+    GENERIC,
+    NIM
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,8 +3,37 @@
 
 # your OpenAi API key from https://platform.openai.com/api-keys
 # the plugin won't work without this
-
 openAiKey: ""
+
+# Select the inference provider to use for chat completions.
+# Supported values: openai | openrouter | ollama | lmstudio | generic | nim
+inference-provider: openai
+
+# OpenRouter (OpenAI-compatible cloud proxy)
+openRouterKey: ""
+openRouterUrl: "https://api.openrouter.ai/v1"
+
+# Ollama (local server) — change if your Ollama daemon runs on a different host/port **tool calls are not currently supported when using Ollama**
+ollamaUrl: "http://localhost:11434"
+
+# LM Studio (local server) — change if your LM Studio host/port differ
+# LM Studio exposes an OpenAI-compatible chat endpoint by default; function/tool calls are supported when
+# `inference-provider` is set to `lmstudio`.
+lmstudioUrl: "http://localhost:1234"
+
+# Generic OpenAI-compatible provider (set base URL and API key)
+# Use this for any service that implements the OpenAI Chat API surface.
+genericUrl: "https://api.your-provider.example"
+genericKey: ""
+
+# NVIDIA NIM (OpenAI-compatible endpoint)
+# Default is the cloud endpoint; change if using a self-hosted NIM gateway.
+nimUrl: "https://integrate.api.nvidia.com/v1"
+nimKey: ""
+
+# Optional NIM-specific parameters passed in the request body (JSON).
+# Example: {"chat_template_kwargs": {"enable_thinking": true, "clear_thinking": false}}
+nimExtraBody: "{}"
 
 # language in ISO-639 format https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 language: en


### PR DESCRIPTION
Add support for multiple LLM providers (Ollama, LM Studio, OpenRouter, NVIDIA NIM, and generic). Includes dynamic URL resolution, auth header handling, prompt conversion for non-OpenAI providers, and unified response parsing across different API response formats.